### PR TITLE
If the file is empty or is named "master.todo" then use 'e' instead

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -220,7 +220,7 @@ function! s:common_sink(action, lines) abort
     let autochdir = &autochdir
     set noautochdir
     for item in a:lines
-      if empty
+      if empty || expand('%:t') == "master.todo"
         execute 'e' s:escape(item)
         let empty = 0
       else


### PR DESCRIPTION
Normally the file is only opened using 'e' if the current buffer is empty.  Now 'e' is used if the file is empty or if the file is named "master.todo"